### PR TITLE
Add instruction to install nbgrader and activate the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ cd formgradernext
 virtualenv -p python3 venv
 source venv/bin/activate
 ```
+3. Install NBGrader
+```bash
+pip install nbgrader
+jupyter nbextension install --sys-prefix --py nbgrader --overwrite
+jupyter nbextension enable --sys-prefix --py nbgrader
+jupyter serverextension enable --sys-prefix --py nbgrader
+```
 
-3. Install and Activate Extensions
+4. Install and Activate formgradernext Extensions
 
 Install and activate all extensions (assignment list, create assignment, formgrader, and validate):
 


### PR DESCRIPTION
A small missing step (that took a while for me to figure out this was the reason): you need to install `nbgrader` and activate its extensions. I first imagined that, as this has `nbgrader` in the requirements, it wouldn't be necessary.

Without those extensions you get a cryptic error message: `nbgrader_bad_setup`, when I disabled that check I diagnosed it to be that the nbgrader extensions load some config file that this plugin doesn't on its own.

Perhaps it's obvious, but it stumped me for a bit - hence its worth adding the instruction :).