### PR TITLE
Add COEP and COEP header middleware decorator and wildcard route

### DIFF
--- a/formgradernext/middleware.py
+++ b/formgradernext/middleware.py
@@ -1,0 +1,16 @@
+from functools import wraps
+from tornado.web import RequestHandler
+
+
+def coop_coep_headers(f):
+    """
+    Sets the COOP and COEP headers, which are required for cross origin isolation (which unlocks
+    certain features in embedded Starboard Notebook frames). These headers need to be present
+    all the way down (i.e. in the top level webpage, as well as )
+    """
+    @wraps(f)
+    def handle(self: RequestHandler, *args, **kwargs):
+        self.set_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.set_header("Cross-Origin-Opener-Policy", "same-origin")
+        return f(self, *args, **kwargs)
+    return handle


### PR DESCRIPTION
To be able to use Starboard notebook to its full potential we need to set the COOP and COEP header. This is required for Atomics and SharedArrayBuffer to be used since the Spectre vulnerabilities (you can check in the browser console by typing `crossOriginIsolated` which should be `true` if everything is good).

This PR introduces a middleware (not sure what they are called in Tornado, but I suppose its implemented as a decorator) that sets these headers to the correct value.

---
With these headers we basically opt in to a stricter set of security rules (which is not a bad idea anyway!), but there's a bit of work required before everything will work again:

1. All assets loaded from a different origin must have the `crossorigin` attribute set. So it would be `<script src="https://content.illumidesk.com/my-javascript-file.js" crossorigin></script>`. **This likely means that we have to change some setting in our lms build pipeline that adds these tags**. In webpack it's [`output.crossOriginLoading`](https://github.com/gzuidhof/starboard-notebook/blob/master/webpack.config.js#L19).
2. Alternatively we can proxy all requests from the CDN through the formgradernext server (it's not that crazy, we already do it for the `index.html`).
3. For option 1 to work, we need to set the correct CORS headers (ACAO, aka Access-Control-Allow-Origin) for `content.illumidesk.com`. We can set that to a wildcard `*` (most CDNs will do this, alternatively it could check the origin and see if it's in a whitelist - but that requires server logic in front of it). Screenshot of issue: ![](https://user-images.githubusercontent.com/1039510/130374072-6905a40d-9185-4068-9ee7-8b4ddfa0a65a.png)
4. All paths of content.illumidesk.com should have this header:
```json
{
          "key": "Cross-Origin-Resource-Policy",
          "value": "cross-origin"
}
```
5. The paths under `https://content.illumidesk.com/npm/starboard-notebook` (e.g. `npm/starboard-notebook@0.13.2/dist/index.html`) should additionally have the following headers set: 
  ```json
        {
          "key": "Cross-Origin-Embedder-Policy",
          "value": "require-corp"
        },
        {
          "key": "Cross-Origin-Opener-Policy",
          "value": "same-origin"
        }
```
(We have a crazy hack from Stefan to not actually require step 5, but we should not rely on that).



