### PR TITLE
Update common.js to fix path and grader console tab

### DIFF
--- a/formgradernext/_version.py
+++ b/formgradernext/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 3, 2)
+version_info = (0, 3, 3)
 __version__ = ".".join(map(str, version_info))

--- a/formgradernext/static/common.js
+++ b/formgradernext/static/common.js
@@ -22,7 +22,7 @@ $(function() {
     $('.jupyter-logo').html(logoSvg);
     $('#header-container #ipython_notebook a').html('IllumiDesk').attr('style', commonStyle);
     var formGraderPath = window.location.pathname.replace(/\/tree\/?.*$/, '') + '/formgradernext';
-    if (/\/tree\/?$/.test(window.location.pathname) && $('a[href="' + formGraderPath + '"]').length === 0) {
+    if (/\/tree\/?/.test(window.location.pathname) && $('a[href="' + formGraderPath + '"]').length === 0) {
         $("#tabs").append(
             $('<li>')
             .append(

--- a/formgradernext/static/common.js
+++ b/formgradernext/static/common.js
@@ -21,7 +21,7 @@ $(function() {
     $('.col-md-2 .page-header h1').text('Grader Console');
     $('.jupyter-logo').html(logoSvg);
     $('#header-container #ipython_notebook a').html('IllumiDesk').attr('style', commonStyle);
-    var formGraderPath = window.location.pathname.replace(/\/tree\/?$/, '') + '/formgradernext';
+    var formGraderPath = window.location.pathname.replace(/\/tree\/?.*$/, '') + '/formgradernext';
     if (/\/tree\/?$/.test(window.location.pathname) && $('a[href="' + formGraderPath + '"]').length === 0) {
         $("#tabs").append(
             $('<li>')


### PR DESCRIPTION
- Updates the path used by the Grader Console tab so that it replaces the `/tree` part in the path with `/formgradernext` to resolve 404 errors.
- Updates logic to display Grader Console tab from any path location in the Jupyter file manager